### PR TITLE
Add API gateway with queue and cancellation

### DIFF
--- a/api-gateway/main.py
+++ b/api-gateway/main.py
@@ -1,0 +1,74 @@
+import asyncio
+import json
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from queue_service import queue_service
+
+app = FastAPI(title="API Gateway")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:8501", "http://localhost:8502"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+security = HTTPBearer()
+
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    if credentials.credentials != "user_token":
+        raise HTTPException(status_code=401, detail="Invalid user credentials")
+    return {"role": "user"}
+
+
+def get_admin_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    if credentials.credentials != "admin_token":
+        raise HTTPException(status_code=401, detail="Invalid admin credentials")
+    return {"role": "admin"}
+
+
+@app.websocket("/api/user/chat")
+async def websocket_chat(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            message_data = json.loads(data)
+            message = message_data.get("message", "")
+            thread_id = message_data.get("thread_id", "default")
+
+            request_id = await queue_service.enqueue(message, thread_id)
+            await websocket.send_text(json.dumps({"type": "queued", "request_id": request_id}))
+
+            while True:
+                chunk = await queue_service.pending[request_id].response_queue.get()
+                if chunk is None:
+                    break
+                await websocket.send_text(json.dumps({"type": "response_chunk", "data": chunk, "request_id": request_id}))
+
+            await websocket.send_text(json.dumps({"type": "response_complete", "request_id": request_id}))
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        await websocket.send_text(json.dumps({"type": "error", "data": str(e)}))
+
+
+@app.delete("/api/user/requests/{request_id}")
+async def cancel_request(request_id: str, user=Depends(get_current_user)):
+    success = await queue_service.cancel(request_id)
+    if success:
+        return {"success": True}
+    raise HTTPException(status_code=404, detail="Request not found")
+
+
+@app.get("/api/admin/queue")
+async def queue_status(admin=Depends(get_admin_user)):
+    return {"queue": queue_service.status()}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/queue_service.py
+++ b/queue_service.py
@@ -1,0 +1,54 @@
+import asyncio
+import uuid
+from typing import Dict, Optional, List
+
+class RequestItem:
+    def __init__(self, message: str, thread_id: str):
+        self.id = str(uuid.uuid4())
+        self.message = message
+        self.thread_id = thread_id
+        self.response_queue: asyncio.Queue[str | None] = asyncio.Queue()
+        self.status = "queued"
+
+class QueueService:
+    def __init__(self):
+        self.queue: asyncio.Queue[str] = asyncio.Queue()
+        self.pending: Dict[str, RequestItem] = {}
+
+    async def enqueue(self, message: str, thread_id: str) -> str:
+        item = RequestItem(message, thread_id)
+        self.pending[item.id] = item
+        await self.queue.put(item.id)
+        return item.id
+
+    async def dequeue(self) -> Optional[RequestItem]:
+        request_id = await self.queue.get()
+        item = self.pending.get(request_id)
+        if not item or item.status == "cancelled":
+            self.pending.pop(request_id, None)
+            return None
+        item.status = "processing"
+        return item
+
+    async def cancel(self, request_id: str) -> bool:
+        item = self.pending.get(request_id)
+        if item and item.status == "queued":
+            item.status = "cancelled"
+            await item.response_queue.put(None)
+            return True
+        return False
+
+    async def complete(self, request_id: str):
+        item = self.pending.pop(request_id, None)
+        if item:
+            item.status = "done"
+            await item.response_queue.put(None)
+
+    def status(self) -> List[Dict[str, str]]:
+        return [
+            {"id": rid, "message": itm.message, "status": itm.status}
+            for rid, itm in self.pending.items()
+            if itm.status in {"queued", "processing"}
+        ]
+
+queue_service = QueueService()

--- a/run_dev.py
+++ b/run_dev.py
@@ -5,6 +5,17 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 
+def run_gateway():
+    base_dir = os.path.dirname(__file__)
+    gateway_path = os.path.abspath(os.path.join(base_dir, 'api-gateway'))
+
+    if not os.path.isdir(gateway_path):
+        raise FileNotFoundError(f"'api-gateway' 폴더를 찾을 수 없습니다: {gateway_path}")
+
+    os.chdir(gateway_path)
+    subprocess.run(['python', 'main.py'])
+
+
 def run_backend():
     base_dir = os.path.dirname(__file__)        # => d:\Architect과정\팀과제\multi-agent\test
     backend_path = os.path.abspath(os.path.join(base_dir, 'backend'))
@@ -44,22 +55,24 @@ def run_admin_frontend():
 def main():
     print("🚀 LangGraph MCP 에이전트 시스템 시작...")
     
-    with ThreadPoolExecutor(max_workers=3) as executor:
-        # 백엔드 먼저 시작
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        gateway_future = executor.submit(run_gateway)
+        time.sleep(3)
         backend_future = executor.submit(run_backend)
-        time.sleep(3)  # 백엔드가 시작될 시간을 줌
+        time.sleep(3)
         
-        # 프론트엔드들 시작
         user_future = executor.submit(run_user_frontend)
-        time.sleep(3)  # 프론트엔드 시작 시간 줌
+        time.sleep(3)
         admin_future = executor.submit(run_admin_frontend)
         
         print("📊 서비스 URL:")
-        print("  - 백엔드 API: http://localhost:8000")
+        print("  - API Gateway: http://localhost:8000")
+        print("  - Backend API: http://localhost:8001")
         print("  - 사용자 인터페이스: http://localhost:8501")
         print("  - 운영자 대시보드: http://localhost:8502")
         
         # 모든 서비스가 종료될 때까지 대기
+        gateway_future.result()
         backend_future.result()
         user_future.result()
         admin_future.result()


### PR DESCRIPTION
## Summary
- implement new `queue_service` providing enqueue/dequeue/cancel logic
- add `api-gateway` to accept websocket requests, queue them and allow admin monitoring
- start background worker in backend to process queued tasks and run on port 8001
- allow user frontend to cancel queued requests and show cancel button
- display queue status in admin dashboard
- update `run_dev.py` to run gateway alongside backend

## Testing
- `python -m py_compile queue_service.py api-gateway/main.py backend/main.py admin-frontend/main.py user-frontend/main.py run_dev.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68412c896a708329ad0bb7ad85d13823