### PR TITLE
Introduce gateway and queue

### DIFF
--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,0 +1,27 @@
+import asyncio
+import json
+from aio_pika import connect_robust
+from aio_pika.patterns import RPC
+from core.agent_service import MCPAgentService
+
+agent_service = MCPAgentService()
+
+async def handle_user_chat(message: str) -> str:
+    data = json.loads(message)
+    if not agent_service.agent:
+        await agent_service.initialize_agent()
+    full = ""
+    async for chunk in agent_service.chat_stream(data["message"], data.get("thread_id", "default")):
+        full += chunk
+    return full
+
+async def main():
+    connection = await connect_robust("amqp://guest:guest@rabbitmq/")
+    channel = await connection.channel()
+    rpc = await RPC.create(channel)
+    await rpc.register("user_chat", handle_user_chat, auto_delete=True)
+    print("Worker started and waiting for tasks...")
+    await asyncio.Future()  # run forever
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docker/api-gateway.Dockerfile
+++ b/docker/api-gateway.Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY gateway/nginx.conf /etc/nginx/nginx.conf

--- a/docker/backend-worker.Dockerfile
+++ b/docker/backend-worker.Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements/backend.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+COPY backend /app/backend
+CMD ["python", "backend/worker.py"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,16 +1,40 @@
 version: '3.8'
 
 services:
-  backend:
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - app_network
+
+  gateway-app:
     build:
       context: .
-      dockerfile: docker/backend.Dockerfile
+      dockerfile: docker/gateway-app.Dockerfile
+    depends_on:
+      - rabbitmq
+    networks:
+      - app_network
+
+  api-gateway:
+    build:
+      context: .
+      dockerfile: docker/api-gateway.Dockerfile
     ports:
-      - "8000:8000"
-    environment:
-      - DATABASE_URL=sqlite:///./shared_data.db
-    volumes:
-      - shared_data:/app/data
+      - "8000:80"
+    depends_on:
+      - gateway-app
+    networks:
+      - app_network
+
+  backend-worker:
+    build:
+      context: .
+      dockerfile: docker/backend-worker.Dockerfile
+    depends_on:
+      - rabbitmq
     networks:
       - app_network
 
@@ -21,9 +45,9 @@ services:
     ports:
       - "8501:8501"
     depends_on:
-      - backend
+      - api-gateway
     environment:
-      - BACKEND_URL=http://backend:8000
+      - BACKEND_URL=http://api-gateway
     networks:
       - app_network
 
@@ -34,9 +58,9 @@ services:
     ports:
       - "8502:8502"
     depends_on:
-      - backend
+      - api-gateway
     environment:
-      - BACKEND_URL=http://backend:8000
+      - BACKEND_URL=http://api-gateway
     networks:
       - app_network
 

--- a/docker/gateway-app.Dockerfile
+++ b/docker/gateway-app.Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements/gateway.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+COPY gateway /app
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import json
+from aio_pika import connect_robust
+from aio_pika.patterns import RPC
+
+app = FastAPI(title="API Gateway")
+
+class ChatRequest(BaseModel):
+    message: str
+    thread_id: str = "default"
+
+@app.on_event("startup")
+async def startup():
+    app.state.connection = await connect_robust("amqp://guest:guest@rabbitmq/")
+    channel = await app.state.connection.channel()
+    app.state.rpc = await RPC.create(channel)
+
+@app.on_event("shutdown")
+async def shutdown():
+    await app.state.connection.close()
+
+@app.post("/api/user/chat")
+async def user_chat(req: ChatRequest):
+    try:
+        rpc: RPC = app.state.rpc
+        response = await rpc.proxy.user_chat(json.dumps(req.dict()))
+        return {"response": response}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -1,0 +1,20 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    upstream gateway_app {
+        server gateway-app:8000;
+    }
+
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://gateway_app;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+        }
+    }
+}

--- a/requirements/backend.txt
+++ b/requirements/backend.txt
@@ -9,3 +9,4 @@ langchain-openai>=0.2.0
 langchain-mcp-adapters>=0.1.0
 langgraph>=0.2.0
 PyYAML>=6.0.0
+aio-pika>=8.3.0

--- a/requirements/gateway.txt
+++ b/requirements/gateway.txt
@@ -1,0 +1,3 @@
+fastapi>=0.104.0
+uvicorn[standard]>=0.24.0
+aio-pika>=8.3.0


### PR DESCRIPTION
## Summary
- add RabbitMQ-based queueing architecture
- create API gateway service and backend worker
- include Dockerfiles and compose updates for new services
- add nginx layer in front of FastAPI gateway

## Testing
- `python -m py_compile backend/worker.py gateway/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6841407925b883299594354ac6576412